### PR TITLE
fix wrong icon_path on config publish

### DIFF
--- a/src/config/fontawesome.php
+++ b/src/config/fontawesome.php
@@ -12,7 +12,7 @@ return [
     |
     */
 
-    'icon_path' => __DIR__ . '/../../../../fortawesome/font-awesome/svgs/',
+    'icon_path' => base_path('/vendor/fortawesome/font-awesome/svgs/'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
The `icon_path` path is currently hard coded, and will break when we publish the `fontawsome.php`.

For example, my config is in my `config/` folder.
The actual path will go outside of the scope of my project.
```php
__DIR__ . '/../../../../fortawesome/font-awesome/svgs/'
```

Using `base_path()` it will avoid this error and the path will still be correct whatever folder the config is.